### PR TITLE
Fix Bazel version inspector

### DIFF
--- a/src/main/java/org/gradle/profiler/VersionInspector.java
+++ b/src/main/java/org/gradle/profiler/VersionInspector.java
@@ -3,6 +3,7 @@ package org.gradle.profiler;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -11,7 +12,7 @@ public class VersionInspector {
     private final static String bazelHome = System.getenv("BAZEL_HOME");
     private final static String bazelExe = bazelHome == null ? "bazel" : bazelHome + "/bin/bazel";
 
-    public final static VersionInspector BAZEL = new VersionInspector("bazel", "bazel", "Build label: (.+)", bazelExe + " version");
+    public final static VersionInspector BAZEL = new VersionInspector("bazel", "bazel", "Build label: (.+)", bazelExe, "version");
     public final static VersionInspector BUCK = new VersionInspector("buck", "buck", "buck version (.+)", "./buckw", "--version");
 
     private Version cachedVersion;


### PR DESCRIPTION
- changed to array instead of single command